### PR TITLE
Flush messages from checkout/session on ajax add

### DIFF
--- a/app/code/community/SomethingDigital/AjaxAddToCart/Model/Observer.php
+++ b/app/code/community/SomethingDigital/AjaxAddToCart/Model/Observer.php
@@ -85,6 +85,9 @@ class SomethingDigital_AjaxAddToCart_Model_Observer
     if($result['status'] === self::STATUS_ERROR){
         $result['message'] = '<ul class="messages"><li class="error-msg"><ul><li class="out-of-stock-error">' . $result['message'] . '</li></ul></li></ul>';
     }
+
+    //clear messages
+    Mage::getSingleton('checkout/session')->getMessages(true);
     
     return $result;
   }


### PR DESCRIPTION
This fixes a bug where any item added or removed from cart did not flush cart session messages. This caused them to appear on subsequent pages.
