### PR TITLE
Add content-type for ajaxUpdate and ajaxDelete

### DIFF
--- a/app/code/community/SomethingDigital/AjaxAddToCart/Model/Observer.php
+++ b/app/code/community/SomethingDigital/AjaxAddToCart/Model/Observer.php
@@ -6,6 +6,34 @@ class SomethingDigital_AjaxAddToCart_Model_Observer
   const STATUS_SUCCESS = 'SUCCESS';
 
   /**
+   * Postdispatch for Cart Delete Action to sniff for Ajax Delete
+   * Clear headers before sending response, to fix duplicate Content-Type issue
+   * @param  Varien_Event_Observer $observer
+   * @return void
+   */
+  public function controllerActionPostdispatchCheckoutCartAjaxDelete(Varien_Event_Observer $observer)
+  {
+    $response = Mage::app()->getResponse();
+
+    $response->clearHeaders()
+      ->setHeader('Content-Type', 'application/json');
+  }
+
+  /**
+   * Postdispatch for Cart Update Action to sniff for Ajax Update
+   * Clear headers before sending response, to fix duplicate Content-Type issue
+   * @param  Varien_Event_Observer $observer
+   * @return void
+   */
+  public function controllerActionPostdispatchCheckoutCartAjaxUpdate(Varien_Event_Observer $observer)
+  {
+    $response = Mage::app()->getResponse();
+
+    $response->clearHeaders()
+      ->setHeader('Content-Type', 'application/json');
+  }
+
+  /**
    * Postdispatch for Cart Add Action to sniff for Ajax Add
    * @param  Varien_Event_Observer $observer 
    * @return void

--- a/app/code/community/SomethingDigital/AjaxAddToCart/etc/config.xml
+++ b/app/code/community/SomethingDigital/AjaxAddToCart/etc/config.xml
@@ -22,6 +22,22 @@
           </sd_ajaxaddtocart>
         </observers>
       </controller_action_postdispatch_checkout_cart_add>
+      <controller_action_postdispatch_checkout_cart_ajaxDelete>
+        <observers>
+          <sd_ajaxdelete>
+            <class>SomethingDigital_AjaxAddToCart_Model_Observer</class>
+            <method>controllerActionPostdispatchCheckoutCartAjaxDelete</method>
+          </sd_ajaxdelete>
+        </observers>
+      </controller_action_postdispatch_checkout_cart_ajaxDelete>
+      <controller_action_postdispatch_checkout_cart_ajaxUpdate>
+        <observers>
+          <sd_ajaxupdate>
+            <class>SomethingDigital_AjaxAddToCart_Model_Observer</class>
+            <method>controllerActionPostdispatchCheckoutCartAjaxUpdate</method>
+          </sd_ajaxupdate>
+        </observers>
+      </controller_action_postdispatch_checkout_cart_ajaxUpdate>
     </events>
   </frontend>
 </config>


### PR DESCRIPTION
This should resolve issues where the content-type is not set to json for specific minicart actions.

This resolves rebase issues in PR for @rnicklin 
