### PR TITLE
Allow configurable product updates to use the ajax cart

### DIFF
--- a/app/code/community/SomethingDigital/AjaxAddToCart/Model/Observer.php
+++ b/app/code/community/SomethingDigital/AjaxAddToCart/Model/Observer.php
@@ -6,6 +6,12 @@ class SomethingDigital_AjaxAddToCart_Model_Observer
   const STATUS_SUCCESS = 'SUCCESS';
 
   /**
+   * Cached core helper instance.  Use _getCoreHelper().
+   * @var Mage_Core_Helper_Data
+   */
+  protected $_coreHelper = null;
+
+  /**
    * Postdispatch for Cart Delete Action to sniff for Ajax Delete
    * Clear headers before sending response, to fix duplicate Content-Type issue
    * @param  Varien_Event_Observer $observer
@@ -40,29 +46,58 @@ class SomethingDigital_AjaxAddToCart_Model_Observer
    */
   public function controllerActionPostdispatchCheckoutCartAdd(Varien_Event_Observer $observer)
   {
-    /* @var $coreHelper Mage_Core_Helper_Abstract */
-    $coreHelper   = Mage::helper('core');
-
     $controllerAction = $observer->getControllerAction();
     $response         = Mage::app()->getResponse();
-    $responseCode     = 200;
 
     if(!$controllerAction->getRequest()->isAjax()) {
       return;
     }
 
-    $result = $this->_buildResponse($observer, $controllerAction, $coreHelper);
+    $result = $this->_buildAddResponse($controllerAction);
+    $this->_sendAjaxResponse($response, $result);
+  }
 
+  /**
+   * Postdispatch for Cart reconfigure action to update the mini cart
+   * @param  Varien_Event_Observer $observer
+   * @return void
+   */
+  public function controllerActionPostdispatchCheckoutCartUpdateItemOptions(Varien_Event_Observer $observer)
+  {
+    $controllerAction = $observer->getControllerAction();
+    $response         = Mage::app()->getResponse();
+
+    if(!$controllerAction->getRequest()->isAjax()) {
+      return;
+    }
+
+    $result = $this->_buildUpdateResponse($controllerAction);
+    $this->_sendAjaxResponse($response, $result);
+  }
+
+  protected function _sendAjaxResponse($response, $result)
+  {
     $response->clearAllHeaders();
     $responseCode = $result['status'] === self::STATUS_SUCCESS ? 200 : 520;
     $response->setHttpResponseCode($responseCode);
 
     $response->clearHeaders()
       ->setHeader('Content-Type', 'application/json')
-      ->setBody($coreHelper->jsonEncode($result));
+      ->setBody($this->_getCoreHelper()->jsonEncode($result));
   }
 
-  protected function _buildResponse($observer, $controllerAction, $coreHelper)
+  protected function _buildAddResponse($controllerAction)
+  {
+    return $this->_buildCommonResponse($controllerAction, '%s was added to your shopping cart.', 'Cannot add the item to shopping cart.');
+  }
+
+  protected function _buildUpdateResponse($controllerAction)
+  {
+    $result = $this->_buildCommonResponse($controllerAction, '%s was updated in your shopping cart.', 'Cannot update the item.');
+    return $result;
+  }
+
+  protected function _buildCommonResponse($controllerAction, $successMessage, $errorMessage)
   {
     /* @var $catalogModel Mage_Core_Model_Catalog_Product */
     $catalogModel = Mage::getModel('catalog/product');
@@ -76,33 +111,57 @@ class SomethingDigital_AjaxAddToCart_Model_Observer
 
       if (!$product) {
         $result['status']  = self::STATUS_ERROR;
-        $result['message'] = $coreHelper->__('Unable to find Product ID');
+        $result['message'] = $this->_getCoreHelper()->__('Unable to find Product ID');
         return $result;
       }
 
       //assemble the message
-      $message = $coreHelper->__('%s was added to your shopping cart.', $coreHelper->htmlEscape($product->getName()));
+      $message = $this->_getCoreHelper()->__($successMessage, $this->_getCoreHelper()->htmlEscape($product->getName()));
       $result['status'] = self::STATUS_SUCCESS;
       $result['message'] = $message;
-      $controllerAction->loadLayout();
-      $sidebar = $controllerAction->getLayout()->getBlock('minicart_head')->toHtml();
-      $result['minicart_head'] = '<div class="header-minicart minicart--fixed">' . $sidebar . '</div>';
+      $result['minicart_head'] = $this->_getMinicartHtml($controllerAction);
 
     } catch(Mage_Core_Exception $e) {
+      $result['status'] = self::STATUS_ERROR;
+      $result['message'] = $this->_getCoreHelper()->__($errorMessage);
 
-          $result['status'] = self::STATUS_ERROR;
-          $result['message'] = $coreHelper->__('Cannot add the item to shopping cart.');
-
-          Mage::logException($e);
+      Mage::logException($e);
     }
 
     if($result['status'] === self::STATUS_ERROR){
-        $result['message'] = '<ul class="messages"><li class="error-msg"><ul><li class="out-of-stock-error">' . $result['message'] . '</li></ul></li></ul>';
+      $result['message'] = $this->_formatErrorMessage($result['message']);
     }
 
     //clear messages
     Mage::getSingleton('checkout/session')->getMessages(true);
     
     return $result;
+  }
+
+  protected function _formatErrorMessage($htmlMessage)
+  {
+    return '<ul class="messages"><li class="error-msg"><ul><li class="out-of-stock-error">' . $htmlMessage . '</li></ul></li></ul>';
+  }
+
+  /**
+   * Retrieve the minicart_head block's html
+   * @param Mage_Core_Controller_Varien_Action $controllerAction the request's controller
+   * @return string
+   */
+  protected function _getMinicartHtml($controllerAction)
+  {
+    $controllerAction->loadLayout();
+    $sidebar = $controllerAction->getLayout()->getBlock('minicart_head')->toHtml();
+    return '<div class="header-minicart minicart--fixed">' . $sidebar . '</div>';
+  }
+
+  protected function _getCoreHelper()
+  {
+    if ($this->_coreHelper === null) {
+      /** @var Mage_Core_Helper_Data $helper */
+      $helper = Mage::helper('core');
+      $this->_coreHelper = $helper;
+    }
+    return $this->_coreHelper;
   }
 }

--- a/app/code/community/SomethingDigital/AjaxAddToCart/Model/Observer.php
+++ b/app/code/community/SomethingDigital/AjaxAddToCart/Model/Observer.php
@@ -6,10 +6,26 @@ class SomethingDigital_AjaxAddToCart_Model_Observer
   const STATUS_SUCCESS = 'SUCCESS';
 
   /**
+   * Retain the most recently updated item for the update response.
+   * @var Mage_Sales_Model_Quote_Item
+   */
+  protected $_lastUpdatedItem = null;
+
+  /**
    * Cached core helper instance.  Use _getCoreHelper().
    * @var Mage_Core_Helper_Data
    */
   protected $_coreHelper = null;
+
+  /**
+   * Listener to update $this->_lastUpdatedItem.
+   * @param  Varien_Event_Observer $observer
+   * @return void
+   */
+  public function checkoutCartUpdateItemComplete(Varien_Event_Observer $observer)
+  {
+    $this->_lastUpdatedItem = $observer->getItem();
+  }
 
   /**
    * Postdispatch for Cart Delete Action to sniff for Ajax Delete
@@ -94,6 +110,9 @@ class SomethingDigital_AjaxAddToCart_Model_Observer
   protected function _buildUpdateResponse($controllerAction)
   {
     $result = $this->_buildCommonResponse($controllerAction, '%s was updated in your shopping cart.', 'Cannot update the item.');
+    if ($this->_lastUpdatedItem !== null) {
+      $result['product_addtocart_form_action'] = Mage::getUrl('checkout/cart/updateItemOptions', array('id' => $this->_lastUpdatedItem->getId()));
+    }
     return $result;
   }
 

--- a/app/code/community/SomethingDigital/AjaxAddToCart/etc/config.xml
+++ b/app/code/community/SomethingDigital/AjaxAddToCart/etc/config.xml
@@ -38,6 +38,14 @@
           </sd_ajaxupdate>
         </observers>
       </controller_action_postdispatch_checkout_cart_ajaxUpdate>
+      <controller_action_postdispatch_checkout_cart_updateItemOptions>
+        <observers>
+          <sd_ajaxupdate>
+            <class>SomethingDigital_AjaxAddToCart_Model_Observer</class>
+            <method>controllerActionPostdispatchCheckoutCartUpdateItemOptions</method>
+          </sd_ajaxupdate>
+        </observers>
+      </controller_action_postdispatch_checkout_cart_updateItemOptions>
     </events>
   </frontend>
 </config>

--- a/app/code/community/SomethingDigital/AjaxAddToCart/etc/config.xml
+++ b/app/code/community/SomethingDigital/AjaxAddToCart/etc/config.xml
@@ -46,6 +46,14 @@
           </sd_ajaxupdate>
         </observers>
       </controller_action_postdispatch_checkout_cart_updateItemOptions>
+      <checkout_cart_update_item_complete>
+        <observers>
+          <sd_ajaxupdate>
+            <class>SomethingDigital_AjaxAddToCart_Model_Observer</class>
+            <method>checkoutCartUpdateItemComplete</method>
+          </sd_ajaxupdate>
+        </observers>
+      </checkout_cart_update_item_complete>
     </events>
   </frontend>
 </config>

--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -27,6 +27,12 @@
                                 var headerCartHtml = $updatedCart.find('#header-cart').html();
                                 var skipCartHtml   = $updatedCart.find('.skip-cart').html();
 
+                                // Do we need to update the product form's action?
+                                // This allows one to continue configuring, for example.
+                                if (data.product_addtocart_form_action) {
+                                    $('#product_addtocart_form').prop('action', data.product_addtocart_form_action);
+                                }
+
                                 $body.removeClass('locked');
 
                                 // If add to cart from quickview, close quickview


### PR DESCRIPTION
This hooks the updateItemOptions action, and sends back an update for it.  It also correctly returns the new product update URL, so that the page can continue working without reloading (in case they change their mind again.)

Also refactored a tiny bit.
