### PR TITLE
Show checkout session error messages

### DIFF
--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -62,7 +62,8 @@
                                 // Fire success event on success and pass through data returned from response
                                 $(document).trigger("sd_ajaxaddtocart:success", data);
                             })
-                            .fail(function(data){
+                            .fail(function(jqXHR){
+                                var data = jqXHR.responseJSON;
                                 // display failure message
                                 // if add to cart from quickview
                                 if(typeof(window.sdQuickView) == "object" && $('#sd-quickview').is(':visible')) {


### PR DESCRIPTION
This way, if an error was generated while adding to cart, it'll show.  Previously, it would silently skip the error.
