### PR TITLE
Change default for scroll to false

### DIFF
--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -6,7 +6,7 @@
         init:function(productAddToCartForm, options) {
 
             var settings = $.extend({
-                scroll: true,
+                scroll: false,
                 scrollDuration: 250,
                 triggerMinicart: true
             }, options);


### PR DESCRIPTION
A large number of clients have requested the Add to Cart functionality does not scroll to top. The behavior of scrolling should be an option, but not the default one since it goes against the purpose of this extension, which is to let the user add to their cart without disrupting the browsing experience. When it scroll to top, it's very much like refreshing the page.
