### PR TITLE
Default to a no scroll functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Configurable JS Options
 --
 | Option           |  Default                             |  Description                                               |
 |------------------|--------------------------------------|------------------------------------------------------------|
-| scroll             | true                                    | This will scroll the page up and open mini cart on success. |
+| scroll             | false                                    | This will scroll the page up and open mini cart on success instead of displaying a success popup. |
 | scrollDuration             | 250                                    | Duration of scroll animation in ms. |
+| popupDuration             | 5                                    | Duration in seconds that the pop up notification displays. |
 | triggerMinicart             | true                                    | This will show the minicart when product added successfully. |
 
 Events Fired through JS

--- a/app/code/community/SomethingDigital/AjaxAddToCart/etc/config.xml
+++ b/app/code/community/SomethingDigital/AjaxAddToCart/etc/config.xml
@@ -55,5 +55,14 @@
         </observers>
       </checkout_cart_update_item_complete>
     </events>
+    <translate>
+      <modules>
+        <SomethingDigital_AjaxAddToCart>
+          <files>
+            <default>SomethingDigital_AjaxAddToCart.csv</default>
+          </files>
+        </SomethingDigital_AjaxAddToCart>
+      </modules>
+    </translate>
   </frontend>
 </config>

--- a/app/design/frontend/base/default/layout/somethingdigital_ajaxaddtocart.xml
+++ b/app/design/frontend/base/default/layout/somethingdigital_ajaxaddtocart.xml
@@ -9,6 +9,7 @@
         <action method="addItem"><type>skin_js</type><name>js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js</name></action>
       </block>
       <block type="core/template" name="ajaxaddtocart-popup" after="-" template="somethingdigital/ajaxaddtocart/page/html/popup.phtml" />
+      <block type="core/template" name="ajaxaddtocart-showcase" after="-" template="somethingdigital/ajaxaddtocart/page/html/showcase.phtml" />
     </reference>
   </product_list>
 
@@ -21,6 +22,7 @@
         <action method="addItem"><type>skin_js</type><name>js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js</name></action>
       </block>
       <block type="core/template" name="ajaxaddtocart-popup" after="-" template="somethingdigital/ajaxaddtocart/page/html/popup.phtml" />
+      <block type="core/template" name="ajaxaddtocart-showcase" after="-" template="somethingdigital/ajaxaddtocart/page/html/showcase.phtml" />
     </reference>
   </catalog_product_view>
 </layout>

--- a/app/design/frontend/base/default/layout/somethingdigital_ajaxaddtocart.xml
+++ b/app/design/frontend/base/default/layout/somethingdigital_ajaxaddtocart.xml
@@ -1,18 +1,26 @@
 <?xml version="1.0"?>
 <layout>
   <product_list>
+    <reference name="head">
+      <action method="addItem"><type>skin_css</type><name>css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css</name></action>
+    </reference>
     <reference name="before_body_end">
       <block type="page/html_head" name="ajaxaddtocart-js" after="-" template="somethingdigital/ajaxaddtocart/page/html/footer-js.phtml">
         <action method="addItem"><type>skin_js</type><name>js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js</name></action>
       </block>
+      <block type="core/template" name="ajaxaddtocart-popup" after="-" template="somethingdigital/ajaxaddtocart/page/html/popup.phtml" />
     </reference>
   </product_list>
 
   <catalog_product_view>
+    <reference name="head">
+      <action method="addItem"><type>skin_css</type><name>css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css</name></action>
+    </reference>
     <reference name="before_body_end">
-      <block type="page/html_head" name="ajaxaddtocart-js" after="-" template="somethingdigital/ajaxaddtocart/page/html/footer-js.phtml">
+      <block type="page/html_head" name="ajaxaddtocart-popup" after="-" template="somethingdigital/ajaxaddtocart/page/html/footer-js.phtml">
         <action method="addItem"><type>skin_js</type><name>js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js</name></action>
       </block>
+      <block type="core/template" name="ajaxaddtocart-popup" after="-" template="somethingdigital/ajaxaddtocart/page/html/popup.phtml" />
     </reference>
   </catalog_product_view>
 </layout>

--- a/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
@@ -1,13 +1,15 @@
+<?php // *DO NOT* Edit the class or id name of the ajax-atc___pop-up--template div.
+      // Feel free to customize anything inside it to your crazy desires ?>
 <div id="ajax-atc___pop-up--template" class="ajax-atc___pop-up--template">
   <div class="atc-pop-up">
     <div class="atc-pop-up__header">
       <h3><?php echo $this->__('Added to Cart'); ?></h3>
     </div>
-    <p class="atc-pop-up__notification">
-      <?php echo $this->__('{{product}} was added to your bag'); ?>
-    </p>
-    <div class="atc-pop-up__buttons-set">
-      <a href="<?php echo Mage::helper('checkout/cart')->getCartUrl(); ?>" class="button--secondary"><?php echo $this->__('Go to Cart'); ?></a>
+    <div class="atc-pop-up__content">
+      <p class="atc-pop-up__message"></p>
+      <div class="atc-pop-up__buttons-set">
+        <a href="<?php echo Mage::helper('checkout/cart')->getCartUrl(); ?>" class="button--secondary"><?php echo $this->__('Go to Cart'); ?></a>
+      </div>
     </div>
   </div>
 </div>

--- a/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
@@ -4,7 +4,7 @@
   <div class="sd-ajaxatcart-popup">
     <div class="sd-ajaxatcart-popup__header">
       <h3><?php echo $this->__('Added to Cart'); ?></h3>
-      <a class="sd-ajaxatcart-popup__close">Close</a>
+      <a class="sd-ajaxatcart-popup__close"><?php echo $this->__('Close'); ?></a>
     </div>
     <div class="sd-ajaxatcart-popup__content">
       <p class="sd-ajaxatcart-popup__message">

--- a/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
@@ -1,0 +1,13 @@
+<div id="ajax-atc___pop-up--template" class="ajax-atc___pop-up--template">
+  <div class="atc-pop-up">
+    <div class="atc-pop-up__header">
+      <h3><?php echo $this->__('Added to Cart'); ?></h3>
+    </div>
+    <p class="atc-pop-up__notification">
+      <?php echo $this->__('{{product}} was added to your bag'); ?>
+    </p>
+    <div class="atc-pop-up__buttons-set">
+      <a href="<?php echo Mage::helper('checkout/cart')->getCartUrl(); ?>" class="button--secondary"><?php echo $this->__('Go to Cart'); ?></a>
+    </div>
+  </div>
+</div>

--- a/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
@@ -4,14 +4,14 @@
   <div class="sd-ajaxatcart-popup">
     <div class="sd-ajaxatcart-popup__header">
       <h3><?php echo $this->__('Added to Cart'); ?></h3>
-      <a class="sd-ajaxatcart-popup__close">Close</p>
+      <a class="sd-ajaxatcart-popup__close">Close</a>
     </div>
     <div class="sd-ajaxatcart-popup__content">
       <p class="sd-ajaxatcart-popup__message">
         <?php echo $this->__('The product was added to your cart'); ?>
       </p>
-      <div class="sd-ajaxatcart-popup__psuedo-button">
-        <a href="<?php echo Mage::helper('checkout/cart')->getCartUrl(); ?>" class="button--secondary"><?php echo $this->__('Go to Cart'); ?></a>
+      <div class="atc-pop-up__buttons-set">
+        <a href="<?php echo Mage::helper('checkout/cart')->getCartUrl(); ?>" class="sd-ajaxatcart-popup__psuedo-button"><?php echo $this->__('Go to Cart'); ?></a>
       </div>
     </div>
   </div>

--- a/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
@@ -4,9 +4,12 @@
   <div class="atc-pop-up">
     <div class="atc-pop-up__header">
       <h3><?php echo $this->__('Added to Cart'); ?></h3>
+      <p class="atc-pop-up__close">Close</p>
     </div>
     <div class="atc-pop-up__content">
-      <p class="atc-pop-up__message"></p>
+      <p class="atc-pop-up__message">
+        <?php echo $this->__('The product was added to your cart'); ?>
+      </p>
       <div class="atc-pop-up__buttons-set">
         <a href="<?php echo Mage::helper('checkout/cart')->getCartUrl(); ?>" class="button--secondary"><?php echo $this->__('Go to Cart'); ?></a>
       </div>

--- a/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
@@ -1,16 +1,16 @@
-<?php // *DO NOT* Edit the class or id name of the ajax-atc___pop-up--template div.
+<?php // *DO NOT* Edit the class or id name of the sd-ajaxatcart___pop-up--template div.
       // Feel free to customize anything inside it to your crazy desires ?>
-<div id="ajax-atc___pop-up--template" class="ajax-atc___pop-up--template">
-  <div class="atc-pop-up">
-    <div class="atc-pop-up__header">
+<div id="sd-ajaxatcart___pop-up--template" class="sd-ajaxatcart___pop-up--template">
+  <div class="sd-ajaxatcart-popup">
+    <div class="sd-ajaxatcart-popup__header">
       <h3><?php echo $this->__('Added to Cart'); ?></h3>
-      <p class="atc-pop-up__close">Close</p>
+      <a class="sd-ajaxatcart-popup__close">Close</p>
     </div>
-    <div class="atc-pop-up__content">
-      <p class="atc-pop-up__message">
+    <div class="sd-ajaxatcart-popup__content">
+      <p class="sd-ajaxatcart-popup__message">
         <?php echo $this->__('The product was added to your cart'); ?>
       </p>
-      <div class="atc-pop-up__buttons-set">
+      <div class="sd-ajaxatcart-popup__psuedo-button">
         <a href="<?php echo Mage::helper('checkout/cart')->getCartUrl(); ?>" class="button--secondary"><?php echo $this->__('Go to Cart'); ?></a>
       </div>
     </div>

--- a/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/popup.phtml
@@ -4,7 +4,7 @@
   <div class="sd-ajaxatcart-popup">
     <div class="sd-ajaxatcart-popup__header">
       <h3><?php echo $this->__('Added to Cart'); ?></h3>
-      <a class="sd-ajaxatcart-popup__close"><?php echo $this->__('Close'); ?></a>
+      <a href="#" class="sd-ajaxatcart-popup__close"><?php echo $this->__('Close'); ?></a>
     </div>
     <div class="sd-ajaxatcart-popup__content">
       <p class="sd-ajaxatcart-popup__message">

--- a/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/showcase.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/showcase.phtml
@@ -1,3 +1,3 @@
 <?php // Make sure there is no whitespace or line break in the showcase div.
       // We want to make sure that the :empty psuedo-selector worrks properly ?>
-<div id="ajax-atc___pop-up--showcase" class="ajax-atc___pop-up--showcase"></div>
+<div id="sd-ajaxatcart___pop-up--showcase" class="sd-ajaxatcart___pop-up--showcase"></div>

--- a/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/showcase.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart/page/html/showcase.phtml
@@ -1,0 +1,3 @@
+<?php // Make sure there is no whitespace or line break in the showcase div.
+      // We want to make sure that the :empty psuedo-selector worrks properly ?>
+<div id="ajax-atc___pop-up--showcase" class="ajax-atc___pop-up--showcase"></div>

--- a/app/locale/en_US/SomethingDigital_AjaxAddToCart.csv
+++ b/app/locale/en_US/SomethingDigital_AjaxAddToCart.csv
@@ -1,0 +1,4 @@
+"Added to Cart","Added to Cart"
+"The product was added to your cart","The product was added to your cart"
+"Go to Cart","Go to Cart"
+"Close","Close"

--- a/modman
+++ b/modman
@@ -5,6 +5,7 @@ app/design/frontend/base/default/layout/somethingdigital_ajaxaddtocart.xml
 app/design/frontend/base/default/template/somethingdigital/ajaxaddtocart
 
 # skin
+skin/frontend/base/default/css/somethingdigital/ajaxaddtocart
 skin/frontend/base/default/js/somethingdigital/ajaxaddtocart
 
 # etc

--- a/modman
+++ b/modman
@@ -10,3 +10,6 @@ skin/frontend/base/default/js/somethingdigital/ajaxaddtocart
 
 # etc
 app/etc/modules/SomethingDigital_AjaxAddToCart.xml
+
+# translation
+app/locale/en_US/SomethingDigital_AjaxAddToCart.csv

--- a/skin/frontend/base/default/css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css
+++ b/skin/frontend/base/default/css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css
@@ -43,7 +43,7 @@
   padding: 10px 20px;
   font-size: 12px;
   color: white;
-  cursor: pointer;
+  text-decoration: none;
 }
 
 .sd-ajaxatcart-popup__message {

--- a/skin/frontend/base/default/css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css
+++ b/skin/frontend/base/default/css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css
@@ -1,12 +1,12 @@
-.ajax-atc___pop-up--template {
+.sd-ajaxatcart___pop-up--template {
   display: none;
 }
 
-.ajax-atc___pop-up--showcase:empty {
+.sd-ajaxatcart___pop-up--showcase:empty {
   display: none;
 }
 
-.ajax-atc___pop-up--showcase {
+.sd-ajaxatcart___pop-up--showcase {
   position: fixed;
   top: 0;
   right: 0;
@@ -15,7 +15,7 @@
   z-index: 9999;
 }
 
-.atc-pop-up {
+.sd-ajaxatcart-popup {
   margin: 20px;
   background: white;
   -webkit-box-shadow: 0px 0px 11px 0px rgba(0,0,0,0.5);
@@ -23,20 +23,20 @@
           box-shadow: 0px 0px 11px 0px rgba(0,0,0,0.5);
 }
 
-.atc-pop-up__header {
+.sd-ajaxatcart-popup__header {
   position: relative;
   padding: 10px 20px;
   background-color: #333;
 }
 
-.atc-pop-up__header h3 {
+.sd-ajaxatcart-popup__header h3 {
   margin: 0;
   font-size: 16px;
   color: white;
   text-transform: uppercase;
 }
 
-.atc-pop-up__close {
+.sd-ajaxatcart-popup__close {
   position: absolute;
   top: 0;
   right: 0;
@@ -46,16 +46,16 @@
   cursor: pointer;
 }
 
-.atc-pop-up__message {
+.sd-ajaxatcart-popup__message {
   margin-bottom: 10px;
 }
 
-.atc-pop-up__content {
+.sd-ajaxatcart-popup__content {
   padding: 20px;
   padding-top: 10px;
 }
 
-.button--secondary {
+.sd-ajaxatcart-popup__psuedo-button {
   padding: 11px 20px;
   font-size: 14px;
   line-height: 18px;

--- a/skin/frontend/base/default/css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css
+++ b/skin/frontend/base/default/css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css
@@ -10,12 +10,13 @@
   position: fixed;
   top: 0;
   right: 0;
+  width: 100%;
+  max-width: 425px;
   z-index: 9999;
 }
 
 .atc-pop-up {
   margin: 20px;
-  max-width: 425px;
   background: white;
   -webkit-box-shadow: 0px 0px 11px 0px rgba(0,0,0,0.5);
      -moz-box-shadow: 0px 0px 11px 0px rgba(0,0,0,0.5);
@@ -23,6 +24,7 @@
 }
 
 .atc-pop-up__header {
+  position: relative;
   padding: 10px 20px;
   background-color: #333;
 }
@@ -34,6 +36,16 @@
   text-transform: uppercase;
 }
 
+.atc-pop-up__close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 10px 20px;
+  font-size: 12px;
+  color: white;
+  cursor: pointer;
+}
+
 .atc-pop-up__message {
   margin-bottom: 10px;
 }
@@ -41,4 +53,18 @@
 .atc-pop-up__content {
   padding: 20px;
   padding-top: 10px;
+}
+
+.button--secondary {
+  padding: 11px 20px;
+  font-size: 14px;
+  line-height: 18px;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  border: 0;
+  padding: 10px 20px;
+  color: #000;
+  background-color: #fff;
+  border: 1px solid #1e1c1d;
 }

--- a/skin/frontend/base/default/css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css
+++ b/skin/frontend/base/default/css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css
@@ -1,0 +1,12 @@
+.ajax-atc___pop-up--template {
+  display: none;
+}
+
+.atc-pop-up {
+  position: fixed;
+  top: 0;
+  right: 0;
+  background: #eee;
+  padding: 20px;
+  margin: 20px 30px;
+}

--- a/skin/frontend/base/default/css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css
+++ b/skin/frontend/base/default/css/somethingdigital/ajaxaddtocart/ajaxaddtocart.css
@@ -2,11 +2,43 @@
   display: none;
 }
 
-.atc-pop-up {
+.ajax-atc___pop-up--showcase:empty {
+  display: none;
+}
+
+.ajax-atc___pop-up--showcase {
   position: fixed;
   top: 0;
   right: 0;
-  background: #eee;
+  z-index: 9999;
+}
+
+.atc-pop-up {
+  margin: 20px;
+  max-width: 425px;
+  background: white;
+  -webkit-box-shadow: 0px 0px 11px 0px rgba(0,0,0,0.5);
+     -moz-box-shadow: 0px 0px 11px 0px rgba(0,0,0,0.5);
+          box-shadow: 0px 0px 11px 0px rgba(0,0,0,0.5);
+}
+
+.atc-pop-up__header {
+  padding: 10px 20px;
+  background-color: #333;
+}
+
+.atc-pop-up__header h3 {
+  margin: 0;
+  font-size: 16px;
+  color: white;
+  text-transform: uppercase;
+}
+
+.atc-pop-up__message {
+  margin-bottom: 10px;
+}
+
+.atc-pop-up__content {
   padding: 20px;
-  margin: 20px 30px;
+  padding-top: 10px;
 }

--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -81,11 +81,16 @@
                                   $('#header-cart').removeClass('skip-active');
 
                                   // Clone our template
-                                  var $notification = $notificationTemplate.clone()
-                                  $notification.find('.sd-ajaxatcart-popup__message').text(data.message);
+                                  var $notification = $notificationTemplate.clone();
+
+                                  if (data.message) {
+                                    $notification.find('.sd-ajaxatcart-popup__message').text(data.message);
+                                  }
+
                                   $notification.find('.sd-ajaxatcart-popup__close').on('click', function() {
                                     $notification.hide();
                                   });
+
                                   $notification.appendTo($notificationShowcase).delay(settings.popupDuration * 1000).fadeOut();
                                 }
 

--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -6,8 +6,9 @@
         init:function(productAddToCartForm, options) {
 
             var settings = $.extend({
-                scroll: false,
+                scroll: true,
                 scrollDuration: 250,
+                popupDuration: 500,
                 triggerMinicart: true
             }, options);
 
@@ -75,9 +76,17 @@
 
                                 // Show our popup
                                 if(!settings.scroll) {
+                                  // Close minicart
+                                  $('#header-cart__link').removeClass('skip-active');
+                                  $('#header-cart').removeClass('skip-active');
+
+                                  // Clone our template
                                   var $notification = $notificationTemplate.clone()
                                   $notification.find('.atc-pop-up__message').text(data.message);
-                                  $notification.appendTo($notificationShowcase);
+                                  $notification.find('.atc-pop-up__close').on('click', function() {
+                                    $notification.hide();
+                                  });
+                                  $notification.appendTo($notificationShowcase).delay(settings.popupDuration).fadeOut();
                                 }
 
                             })

--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -35,8 +35,8 @@
                                 var headerCartHtml = $updatedCart.find('#header-cart').html();
                                 var skipCartHtml   = $updatedCart.find('.skip-cart').html();
 
-                                var $notificationTemplate = $('#ajax-atc___pop-up--template').children();
-                                var $notificationShowcase = $('#ajax-atc___pop-up--showcase');
+                                var $notificationTemplate = $('#sd-ajaxatcart___pop-up--template').children();
+                                var $notificationShowcase = $('#sd-ajaxatcart___pop-up--showcase');
 
                                 // Do we need to update the product form's action?
                                 // This allows one to continue configuring, for example.
@@ -82,8 +82,8 @@
 
                                   // Clone our template
                                   var $notification = $notificationTemplate.clone()
-                                  $notification.find('.atc-pop-up__message').text(data.message);
-                                  $notification.find('.atc-pop-up__close').on('click', function() {
+                                  $notification.find('.sd-ajaxatcart-popup__message').text(data.message);
+                                  $notification.find('.sd-ajaxatcart-popup__close').on('click', function() {
                                     $notification.hide();
                                   });
                                   $notification.appendTo($notificationShowcase).delay(settings.popupDuration * 1000).fadeOut();

--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -87,7 +87,8 @@
                                     $notification.find('.sd-ajaxatcart-popup__message').text(data.message);
                                   }
 
-                                  $notification.find('.sd-ajaxatcart-popup__close').on('click', function() {
+                                  $notification.find('.sd-ajaxatcart-popup__close').on('click', function(e) {
+                                    e.preventDefault();
                                     $notification.hide();
                                   });
 

--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -34,6 +34,9 @@
                                 var headerCartHtml = $updatedCart.find('#header-cart').html();
                                 var skipCartHtml   = $updatedCart.find('.skip-cart').html();
 
+                                var $notificationTemplate = $('#ajax-atc___pop-up--template').children();
+                                var $notificationShowcase = $('#ajax-atc___pop-up--showcase');
+
                                 // Do we need to update the product form's action?
                                 // This allows one to continue configuring, for example.
                                 if (data.product_addtocart_form_action) {
@@ -70,10 +73,11 @@
                                 // Fire success event on success and pass through data returned from response
                                 $(document).trigger("sd_ajaxaddtocart:success", data);
 
-                                //show our popup
+                                // Show our popup
                                 if(!settings.scroll) {
-                                  console.log('trying');
-                                  $($('#ajax-atc___pop-up--template').html()).clone().appendTo($body);
+                                  var $notification = $notificationTemplate.clone()
+                                  $notification.find('.atc-pop-up__message').text(data.message);
+                                  $notification.appendTo($notificationShowcase);
                                 }
 
                             })

--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -6,7 +6,7 @@
         init:function(productAddToCartForm, options) {
 
             var settings = $.extend({
-                scroll: true,
+                scroll: false,
                 scrollDuration: 250,
                 triggerMinicart: true
             }, options);
@@ -69,6 +69,13 @@
 
                                 // Fire success event on success and pass through data returned from response
                                 $(document).trigger("sd_ajaxaddtocart:success", data);
+
+                                //show our popup
+                                if(!settings.scroll) {
+                                  console.log('trying');
+                                  $($('#ajax-atc___pop-up--template').html()).clone().appendTo($body);
+                                }
+
                             })
                             .fail(function(jqXHR){
                                 var data = jqXHR.responseJSON;

--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -6,9 +6,9 @@
         init:function(productAddToCartForm, options) {
 
             var settings = $.extend({
-                scroll: true,
+                scroll: false,
                 scrollDuration: 250,
-                popupDuration: 500,
+                popupDuration: 5,
                 triggerMinicart: true
             }, options);
 
@@ -86,7 +86,7 @@
                                   $notification.find('.atc-pop-up__close').on('click', function() {
                                     $notification.hide();
                                   });
-                                  $notification.appendTo($notificationShowcase).delay(settings.popupDuration).fadeOut();
+                                  $notification.appendTo($notificationShowcase).delay(settings.popupDuration * 1000).fadeOut();
                                 }
 
                             })


### PR DESCRIPTION
Instead of scrolling to the top of the page, display a message in the top right that tells you what product has been added to the cart using the add to cart data message. I used a template file that is cloned when the product is added for extra customization. The styling of the message is extremely basic, but easy to customize on a project to project basis.

The popups will display for a small amount of time before fading out. If two things are added to the cart before the message is faded out, they will stack.

Note: I scrolled up manually in this first screenshot to show that the cart isn't expanded.
![screenshot 2016-02-03 17 34 46](https://cloud.githubusercontent.com/assets/9058117/12799602/a6fcb6ba-ca9d-11e5-8200-5a7e8b3d961e.png)

Product added while at mid page:
![screenshot 2016-02-03 17 34 26](https://cloud.githubusercontent.com/assets/9058117/12799603/a6fd5a34-ca9d-11e5-92b6-1e2bf3449771.png)

There have been no accessibility concerns programmed into this PR.
