### PR TITLE
Allow global options variable to override default ones

### DIFF
--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -155,7 +155,10 @@
     };
 
     if (typeof(productAddToCartForm) != "undefined") {
-        sdAjaxaddtocart.init(productAddToCartForm);
+        // override default options with global sdAjaxaddtocartOptions variable
+        var cartOptions = (typeof(sdAjaxaddtocartOptions) != "undefined")? sdAjaxaddtocartOptions : {};
+
+        sdAjaxaddtocart.init(productAddToCartForm, cartOptions);
     }
 
 })(jQuery);


### PR DESCRIPTION
On init, allow options override.

Example:

```
        if (window.sdAjaxaddtocart) {
              var sdAjaxaddtocartOptions = {
                triggerPopup: false,
                triggerMinicart: false,
                triggerLoadingModal: false
              };
            }
```
