### PR TITLE
Wrap form variable in jquery

### DIFF
--- a/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
+++ b/skin/frontend/base/default/js/somethingdigital/ajaxaddtocart/ajaxaddtocart.js
@@ -57,7 +57,7 @@
                                 // Do we need to update the product form's action?
                                 // This allows one to continue configuring, for example.
                                 if (data.product_addtocart_form_action) {
-                                    form.prop('action', data.product_addtocart_form_action);
+                                    $(form).prop('action', data.product_addtocart_form_action);
                                 }
 
                                 $body.removeClass('locked');


### PR DESCRIPTION
Without wrapping it produces the following error:

```
 Uncaught TypeError: form.prop is not a function
```
